### PR TITLE
CC Prototype endpoints

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -976,7 +976,7 @@ class Superset(BaseSupersetView):
             mimetype="application/json")
 
     @log_this
-#   @has_access_api # remove until we figure out auth
+#   @has_access_api # remove until we figure out auth REMOTE_USER
     @expose("/explore_json/<datasource_type>/<datasource_id>/")
     def explore_json(self, datasource_type, datasource_id):
         try:
@@ -990,7 +990,7 @@ class Superset(BaseSupersetView):
                 utils.error_msg_from_exception(e),
                 stacktrace=traceback.format_exc())
 
-        if not self.datasource_access(viz_obj.datasource):
+        if not self.datasource_access(viz_obj.datasource) and request.args.get("restful") != "true":
             return json_error_response(DATASOURCE_ACCESS_ERR, status=404)
 
         if request.args.get("csv") == "true":

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1743,7 +1743,6 @@ class Superset(BaseSupersetView):
     @expose("/dashboard/<dashboard_id>/")
     def dashboard(self, dashboard_id):
         """Server side rendering for a dashboard"""
-        logging.info("in dashboard")
         session = db.session()
         qry = session.query(models.Dashboard)
         if dashboard_id.isdigit():

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -976,7 +976,7 @@ class Superset(BaseSupersetView):
             mimetype="application/json")
 
     @log_this
-    @has_access_api
+#   @has_access_api # remove until we figure out auth
     @expose("/explore_json/<datasource_type>/<datasource_id>/")
     def explore_json(self, datasource_type, datasource_id):
         try:
@@ -1743,6 +1743,7 @@ class Superset(BaseSupersetView):
     @expose("/dashboard/<dashboard_id>/")
     def dashboard(self, dashboard_id):
         """Server side rendering for a dashboard"""
+        logging.info("in dashboard")
         session = db.session()
         qry = session.query(models.Dashboard)
         if dashboard_id.isdigit():
@@ -1799,6 +1800,61 @@ class Superset(BaseSupersetView):
             title='[dashboard] ' + dash.dashboard_title,
             bootstrap_data=json.dumps(bootstrap_data),
         )
+
+    @expose("/dashboard_json/<dashboard_id>/")
+    def dashboard_json(self, dashboard_id):
+        """Server side rendering for a dashboard"""
+        session = db.session()
+        qry = session.query(models.Dashboard)
+        if dashboard_id.isdigit():
+            qry = qry.filter_by(id=int(dashboard_id))
+        else:
+            qry = qry.filter_by(slug=dashboard_id)
+
+        dash = qry.one()
+        datasources = set()
+        for slc in dash.slices:
+            datasource = slc.datasource
+            if datasource:
+                datasources.add(datasource)
+
+        # Commenting until we figure out Authentication from a service
+        # for datasource in datasources:
+        #     if datasource and not self.datasource_access(datasource):
+        #         flash(
+        #             __(get_datasource_access_error_msg(datasource.name)),
+        #             "danger")
+        #         return redirect(
+        #             'superset/request_access/?'
+        #             'dashboard_id={dash.id}&'.format(**locals()))
+
+        # Hack to log the dashboard_id properly, even when getting a slug
+        @log_this
+        def dashboard(**kwargs):  # noqa
+            pass
+        dashboard(dashboard_id=dash.id)
+
+        dash_edit_perm = check_ownership(dash, raise_if_false=False)
+        dash_save_perm = \
+            dash_edit_perm and self.can_access('can_save_dash', 'Superset')
+
+        standalone_mode = request.args.get("standalone") == "true"
+
+        dashboard_data = dash.data
+        dashboard_data.update({
+            'standalone_mode': standalone_mode,
+            'dash_save_perm': dash_save_perm,
+            'dash_edit_perm': dash_edit_perm,
+        })
+
+        bootstrap_data = {
+            'user_id': g.user.get_id(),
+            'dashboard_data': dashboard_data,
+            'datasources': {ds.uid: ds.data for ds in datasources},
+            'common': self.common_bootsrap_payload(),
+        }
+
+        return json_success(json.dumps(bootstrap_data))
 
     @has_access
     @expose("/sync_druid/", methods=['POST'])


### PR DESCRIPTION
Allow Command Center to interact with the Superset's API later
New `dashboard_json` endpoint serializes the normal `dashboard` endpoint into json
Added `restful=true` overrides security checks.

This is an temporary change to unblock FE, while we figure out the best auth

@lyft/command-center @mistercrunch 