### PR TITLE
fix: include json files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -28,6 +28,8 @@ recursive-include superset/static/assets/dist *
 recursive-include superset/static/assets/images *
 recursive-exclude superset/static/images/viz_thumbnails_large *
 recursive-include superset/static/assets/stylesheets *
+include superset/static/assets/version_info.json
+include superset/static/assets/package.json
 
 recursive-include superset/templates *
 recursive-include superset/translations *


### PR DESCRIPTION
This PR broke us - https://github.com/apache/incubator-superset/pull/8109

And this PR has a partial fix - https://github.com/apache/incubator-superset/pull/8148

I have included the fix and also added a second line to include package.json as well which I think is needed. We are in discussion with the developer about this. Until then, we will add this fix to unblock us.