### PR TITLE
update Kepler viz transformProps for latest superset-ui

### DIFF
--- a/superset/assets/src/visualizations/Kepler/transformProps.js
+++ b/superset/assets/src/visualizations/Kepler/transformProps.js
@@ -17,9 +17,16 @@
  * under the License.
  */
 export default function transformProps(chartProps) {
-  const { formData, height, width, queryData, setControlValue } = chartProps;
+  const {
+    formData,
+    height,
+    width,
+    queryData,
+    hooks,
+  } = chartProps;
   const { mapboxApiAccessToken, features } = queryData.data;
   const { config, autozoom, readonly } = formData;
+  const { onAddFilter = NOOP, setControlValue = NOOP, setTooltip = NOOP } = hooks;
   return {
     height,
     width,

--- a/superset/assets/src/visualizations/Kepler/transformProps.js
+++ b/superset/assets/src/visualizations/Kepler/transformProps.js
@@ -26,7 +26,7 @@ export default function transformProps(chartProps) {
   } = chartProps;
   const { mapboxApiAccessToken, features } = queryData.data;
   const { config, autozoom, readonly } = formData;
-  const { onAddFilter = NOOP, setControlValue = NOOP, setTooltip = NOOP } = hooks;
+  const { setControlValue = NOOP } = hooks;
   return {
     height,
     width,

--- a/superset/assets/src/visualizations/Kepler/transformProps.js
+++ b/superset/assets/src/visualizations/Kepler/transformProps.js
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+const NOOP = () => {}
+
 export default function transformProps(chartProps) {
   const {
     formData,

--- a/superset/assets/src/visualizations/Kepler/transformProps.js
+++ b/superset/assets/src/visualizations/Kepler/transformProps.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-const NOOP = () => {}
+const NOOP = () => {};
 
 export default function transformProps(chartProps) {
   const {

--- a/superset/assets/src/visualizations/Kepler/transformProps.js
+++ b/superset/assets/src/visualizations/Kepler/transformProps.js
@@ -17,8 +17,8 @@
  * under the License.
  */
 export default function transformProps(chartProps) {
-  const { formData, height, width, payload, setControlValue } = chartProps;
-  const { mapboxApiAccessToken, features } = payload.data;
+  const { formData, height, width, queryData, setControlValue } = chartProps;
+  const { mapboxApiAccessToken, features } = queryData.data;
   const { config, autozoom, readonly } = formData;
   return {
     height,


### PR DESCRIPTION
#8115 in apache repo introduced breaking changes to chartProps data type, we didn't react to that in our proprietary/cherry changes. :-/

Note, I'm still looking for more potential issues prior to pushing this.