### PR TITLE
Allow bypassing DISPLAY_MAX_ROW

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2504,12 +2504,11 @@ class Superset(BaseSupersetView):
         payload = utils.zlib_decompress(blob, decode=not results_backend_use_msgpack)
         obj = _deserialize_results_payload(payload, query, results_backend_use_msgpack)
 
+        if not request.args.get("bypass_display_limit"):
+            obj = apply_display_max_row_limit(obj)
+
         return json_success(
-            json.dumps(
-                apply_display_max_row_limit(obj),
-                default=utils.json_iso_dttm_ser,
-                ignore_nan=True,
-            )
+            json.dumps(obj, default=utils.json_iso_dttm_ser, ignore_nan=True)
         )
 
     @has_access_api


### PR DESCRIPTION
We need this to unblock a Scope module that's ready to go public. I have a PR merging this upstream (https://github.com/apache/incubator-superset/pull/8389), but it needs unit tests and docs, and we can't merge it to `lyft-master` until we fix Deck.gl, so I created this private commit.

For review: @DiggidyDave @hongbosong @khtruong 
For ack: @dbaishya