### PR TITLE
Revert "Allow bypassing DISPLAY_MAX_ROW"

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2504,11 +2504,12 @@ class Superset(BaseSupersetView):
         payload = utils.zlib_decompress(blob, decode=not results_backend_use_msgpack)
         obj = _deserialize_results_payload(payload, query, results_backend_use_msgpack)
 
-        if not request.args.get("bypass_display_limit"):
-            obj = apply_display_max_row_limit(obj)
-
         return json_success(
-            json.dumps(obj, default=utils.json_iso_dttm_ser, ignore_nan=True)
+            json.dumps(
+                apply_display_max_row_limit(obj),
+                default=utils.json_iso_dttm_ser,
+                ignore_nan=True,
+            )
         )
 
     @has_access_api


### PR DESCRIPTION
This reverts commit 7db65e27a75afb5d93a6a2bdbf55cfec95904ae7, that mas cherry picked into `lyft-master`. It's superseded by https://github.com/apache/incubator-superset/pull/8389/, which is a cleaner approach.