### PR TITLE
fix: update webpack so type-analyzer is not parsed

### DIFF
--- a/lyft_changes.txt
+++ b/lyft_changes.txt
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 This file tracks the changes we have pushed to lyft-master but not apache/incubator-superset master.
 lyft-master is a branch in a Lyft fork of apache/incubator-superset that has cherries applied to it.
 Since then, we have modified these "cherries" and/or added files. Please add changes done to this

--- a/lyft_changes.txt
+++ b/lyft_changes.txt
@@ -1,0 +1,21 @@
+This file tracks the changes we have pushed to lyft-master but not apache/incubator-superset master.
+lyft-master is a branch in a Lyft fork of apache/incubator-superset that has cherries applied to it.
+Since then, we have modified these "cherries" and/or added files. Please add changes done to this
+file to help us track how close or far we are from apache/incubator-superset master.
+
+1. Kepler changes
+- @superset-ui/legacy-preset-chart-kepler has been added to package.json
+- webpack.config.js has been updated to tell Babel not to parse files in the type-analyzer package
+  because it contains CommonJS files. If Babel parses such files, it will mix require and export
+  default in a module, which is not allowed.
+- KeplerChartPreset has been added in superset/assets/src/visualizations/presets/MainPreset.js
+- class KeplerViz in superset/viz.py is still there
+- Two controls ("Read Only Mode" and "Config" controls) in  
+  superset/assets/src/explore/controls.jsx are still there.
+- superset/assets/src/explore/controlPanels/Kepler.js is still there
+- Registering the kepler plugin in superset/assets/src/setup/setupPlugins.ts is still there.
+- kepler dependency in package.json and package-lock.json has been removed
+- superset/assets/src/visualizations/Kepler/Kepler.css has been removed
+- superset/assets/src/visualizations/Kepler/Kepler.jsx has been removed
+- superset/assets/src/visualizations/Kepler/KeplerChartPlugin.js has been removed
+- superset/assets/src/visualizations/presets/DeckGLChartPreset.js has been removed

--- a/superset/assets/webpack.config.js
+++ b/superset/assets/webpack.config.js
@@ -185,6 +185,7 @@ const config = {
         // for debugging @superset-ui packages via npm link
         test: /\.jsx?$/,
         include: /node_modules\/[@]superset[-]ui.+\/src/,
+        exclude: /type[-]analyzer/, // Tell Babel not to parse files in this package bc it contains CommonJs files
         use: [
           {
             loader: 'babel-loader',


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
webpack.config.js has been updated to tell Babel not to parse files in the type-analyzer package because it contains CommonJS files. If Babel parses such files, it will mix require and export default in a module, which is not allowed. I have also added a text file that describes the changes. The purpose of the file is to keep track of changes we push to lyft-master but not to apache/incubator-superset so we have an idea of how close or far lyft-master is from apache/incubator-superset.

### TEST PLAN
Created Kepler chart successfully


### REVIEWERS
@DiggidyDave @betodealmeida @hongbosong 