### PR TITLE
LYFT HACK: prepare and pass req json directly to sql_json_call

### DIFF
--- a/lyft_changes.txt
+++ b/lyft_changes.txt
@@ -36,3 +36,10 @@ file to help us track how close or far we are from apache/incubator-superset mas
 - superset/assets/src/visualizations/Kepler/Kepler.jsx has been removed
 - superset/assets/src/visualizations/Kepler/KeplerChartPlugin.js has been removed
 - superset/assets/src/visualizations/presets/DeckGLChartPreset.js has been removed
+
+2.superset/views/lyft.py and core.py
+We are "intercepting" sql_json and other calls to authenticate then passing down into actual superset functions.  To do this we have added endpoints in lyft.py, but also have broken the apache endpoints (like sql_json) into the request handler itself (ie sql_json) and a shared library function (sql_json_call) that is used by both the apache and lyft version of the endoint.
+
+3. superset/views/core.py again
+in sql_json_call, we have changed the arg to take a json object named request_json (instead of original request) and string replaced all of the usages of request.json to use request_json. This lets us create a dictionary of request param to pass into the sql_json_call method. We need this because our callers such as amundsen are not json encoding data in calls, and superset had a breaking API change that expects them to be encoded.
+

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2681,36 +2681,37 @@ class Superset(BaseSupersetView):
     @expose("/sql_json/", methods=["POST"])
     @event_logger.log_this
     def sql_json(self):
-        return self.sql_json_call(request)
+        request_json = request.json
+        return self.sql_json_call(request_json)
 
-    def sql_json_call(self, request):
+    def sql_json_call(self, request_json):
         """Runs arbitrary sql and returns data as json"""
         # Collect Values
-        database_id: int = request.json.get("database_id")
-        schema: str = request.json.get("schema")
-        sql: str = request.json.get("sql")
+        database_id: int = request_json.get("database_id")
+        schema: str = request_json.get("schema")
+        sql: str = request_json.get("sql")
         try:
             template_params: dict = json.loads(
-                request.json.get("templateParams") or "{}"
+                request_json.get("templateParams") or "{}"
             )
         except json.decoder.JSONDecodeError:
             logging.warning(
-                f"Invalid template parameter {request.json.get('templateParams')}"
+                f"Invalid template parameter {request_json.get('templateParams')}"
                 " specified. Defaulting to empty dict"
             )
             template_params = {}
-        limit = request.json.get("queryLimit") or app.config["SQL_MAX_ROW"]
-        async_flag: bool = request.json.get("runAsync")
+        limit = request_json.get("queryLimit") or app.config["SQL_MAX_ROW"]
+        async_flag: bool = request_json.get("runAsync")
         if limit < 0:
             logging.warning(
                 f"Invalid limit of {limit} specified. Defaulting to max limit."
             )
             limit = 0
-        select_as_cta: bool = request.json.get("select_as_cta")
-        tmp_table_name: str = request.json.get("tmp_table_name")
-        client_id: str = request.json.get("client_id") or utils.shortid()[:10]
-        sql_editor_id: str = request.json.get("sql_editor_id")
-        tab_name: str = request.json.get("tab")
+        select_as_cta: bool = request_json.get("select_as_cta")
+        tmp_table_name: str = request_json.get("tmp_table_name")
+        client_id: str = request_json.get("client_id") or utils.shortid()[:10]
+        sql_editor_id: str = request_json.get("sql_editor_id")
+        tab_name: str = request_json.get("tab")
         status: bool = QueryStatus.PENDING if async_flag else QueryStatus.RUNNING
 
         session = db.session()
@@ -2781,7 +2782,7 @@ class Superset(BaseSupersetView):
         # (feature that will expand Presto row objects and arrays)
         expand_data: bool = is_feature_enabled(
             "PRESTO_EXPAND_DATA"
-        ) and request.json.get("expand_data")
+        ) and request_json.get("expand_data")
 
         # Async request.
         if async_flag:

--- a/superset/views/lyft.py
+++ b/superset/views/lyft.py
@@ -64,20 +64,22 @@ class Lyft(Superset):
         except SupersetException as e:
             return json_error_response("{}".format(e))
 
-        request_json = request.get_json() 
+        request_json = request.get_json()
         if not request_json:
             request_json = {
                 "database_id": int(request.form.get("database_id")),
                 "schema": request.form.get("schema"),
                 "sql": request.form.get("sql"),
                 "templateParams": request.form.get("templateParams", "{}"),
-                "queryLimit": int(request.form.get("queryLimit", app.config.get("SQL_MAX_ROW"))),
+                "queryLimit": int(
+                    request.form.get("queryLimit", app.config.get("SQL_MAX_ROW"))
+                ),
                 "runAsync": request.form.get("runAsync") == "true",
                 "select_as_cta": request.form.get("select_as_cta") == "true",
                 "tmp_table_name": request.form.get("tmp_table_name"),
                 "client_id": request.form.get("client_id") or None,
                 "sql_editor_id": request.form.get("sql_editor_id"),
-                "tab": request.form.get("tab")
+                "tab": request.form.get("tab"),
             }
 
         return self.sql_json_call(request_json)

--- a/superset/views/lyft.py
+++ b/superset/views/lyft.py
@@ -63,7 +63,24 @@ class Lyft(Superset):
             return json_error_response("{}".format(e), status=412)
         except SupersetException as e:
             return json_error_response("{}".format(e))
-        return self.sql_json_call(request)
+
+        request_json = request.get_json() 
+        if not request_json:
+            request_json = {
+                "database_id": int(request.form.get("database_id")),
+                "schema": request.form.get("schema"),
+                "sql": request.form.get("sql"),
+                "templateParams": request.form.get("templateParams", "{}"),
+                "queryLimit": int(request.form.get("queryLimit", app.config.get("SQL_MAX_ROW"))),
+                "runAsync": request.form.get("runAsync") == "true",
+                "select_as_cta": request.form.get("select_as_cta") == "true",
+                "tmp_table_name": request.form.get("tmp_table_name"),
+                "client_id": request.form.get("client_id") or None,
+                "sql_editor_id": request.form.get("sql_editor_id"),
+                "tab": request.form.get("tab")
+            }
+
+        return self.sql_json_call(request_json)
 
     @event_logger.log_this
     @expose("/queries/<last_updated_ms>")


### PR DESCRIPTION
Until we get amundsen and other callers converted to comply with [this sql_json endpoint change at apache](https://github.com/apache/incubator-superset/commit/5d1bf4245d901e8c89922133bc9ca379f5005f51) we need this adapter layer in the Lyft endpoints to package up the json.