### PR TITLE
fix: Catch db_engine_spec.get_function_names exceptions (#9691)

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -165,7 +165,13 @@ class Database(
 
     @property
     def function_names(self) -> List[str]:
-        return self.db_engine_spec.get_function_names(self)
+        try:
+            return self.db_engine_spec.get_function_names(self)
+        except Exception as ex:  # pylint: disable=broad-except
+            # function_names property is used in bulk APIs and should not hard crash
+            # more info in: https://github.com/apache/incubator-superset/issues/9678
+            logger.error(f"Failed to fetch database function names with error: {ex}")
+        return []
 
     @property
     def allows_cost_estimate(self) -> bool:


### PR DESCRIPTION
Cherry-picked https://github.com/apache/incubator-superset/commit/358bbe0c88f7ab5d130be153151c5c1f9eed8639 into the apache-0.36.0 branch. This fix allows us to still get the list of databases even if getting function names for one database fails.